### PR TITLE
Feature/improve waiting list logic and admin display

### DIFF
--- a/djangoplicity/visits/admin.py
+++ b/djangoplicity/visits/admin.py
@@ -181,7 +181,7 @@ class ReservationResource(resources.ModelResource):
 class ReservationAdmin(ImportExportModelAdmin):
     list_display = ('email', 'name', 'activity_name', 'showing_date', 'showing_time', 'phone', 'n_spaces', 'code',
                     'rut', 'vehicle_plate', 'hawaii_state_id_or_drivers_license_number', 'zip_code', 'language', 'created', 'age_range',)
-    list_filter = ('showing__activity', 'showing__start_time', 'created')
+    list_filter = ('showing__activity', 'showing__start_time', 'created', 'is_waiting_list')
     ordering = ['showing__start_time']
     raw_id_fields = ('showing',)
     date_hierarchy = 'showing__start_time'
@@ -189,6 +189,15 @@ class ReservationAdmin(ImportExportModelAdmin):
     search_fields = ('email', 'name')
     list_select_related = ('showing', 'language')
     resource_class = ReservationResource
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+
+        # Check if the admin applied the is_waiting_list filter
+        if "is_waiting_list__exact" not in request.GET:
+            # By default, hide waiting list reservations
+            qs = qs.filter(is_waiting_list=False)
+        return qs
 
     def showing_date(self, obj):
         return obj.showing.start_time.strftime('%Y-%m-%d'),

--- a/djangoplicity/visits/admin.py
+++ b/djangoplicity/visits/admin.py
@@ -179,7 +179,7 @@ class ReservationResource(resources.ModelResource):
 
 
 class ReservationAdmin(ImportExportModelAdmin):
-    list_display = ('email', 'name', 'activity_name', 'showing_date', 'showing_time', 'phone', 'n_spaces', 'code',
+    list_display = ('email', 'name', 'activity_name', 'showing_date', 'showing_time', 'is_waiting_list', 'phone', 'n_spaces', 'code',
                     'rut', 'vehicle_plate', 'hawaii_state_id_or_drivers_license_number', 'zip_code', 'language', 'created', 'age_range',)
     list_filter = ('showing__activity', 'showing__start_time', 'created', 'is_waiting_list')
     ordering = ['showing__start_time']

--- a/djangoplicity/visits/forms.py
+++ b/djangoplicity/visits/forms.py
@@ -234,10 +234,36 @@ class ReservationForm(forms.ModelForm):
                 )
             )
 
+        # Updating an existing reservation
+        if self.instance.pk:
+            old = Reservation.objects.filter(pk=self.instance.pk).first()
+
+            if old and not old.is_waiting_list:
+                # If user reduces or keeps same seats, always allowed
+                if n_spaces <= old.n_spaces:
+                    self.instance.is_waiting_list = False
+                    return n_spaces
+
+                # If user increases seats, must check real availability
+                if n_spaces - old.n_spaces <= free_spaces:
+                    self.instance.is_waiting_list = False
+                    return n_spaces
+
+                # No enough free seats, show clear error
+                raise forms.ValidationError(
+                    _("This exhibition is already fully booked, so we cannot increase the seats in your reservation. "
+                      "If you need more seats, you can create a new reservation, but it will be added to the waiting list in case spots become available.")
+                )
+
+        # Creating a new reservation
         if n_spaces <= free_spaces:
             self.instance.is_waiting_list = False
             return n_spaces
 
+        # Otherwise → try waiting list
+        return self._validate_waiting_list(n_spaces)
+
+    def _validate_waiting_list(self, n_spaces):
         current_reserved = (
             self.showing.reservation_set.aggregate(Sum("n_spaces"))["n_spaces__sum"] or 0
         )
@@ -255,7 +281,6 @@ class ReservationForm(forms.ModelForm):
             "⚠️ This is not a confirmed reservation. "
             "You will be added to the waiting list and contacted if a spot becomes available."
         )
-
         return n_spaces
 
 


### PR DESCRIPTION
 Updated ReservationForm to handle seat increases:
  * Allow users to increase seats if free spaces are available.
  * Show clear error if no seats remain, with option to join waiting list.
 
 Updated ReservationAdmin:
  * By default hide waiting list reservations.
  * Added filter so admins can view waiting list entries when needed.