### PR TITLE
Fix/Add captcha for missing group reservation form to prevent attacks and hide captcha label

### DIFF
--- a/djangoplicity/visits/forms.py
+++ b/djangoplicity/visits/forms.py
@@ -305,6 +305,7 @@ class GroupReservationForm(forms.ModelForm):
         queryset=Activity.objects.filter(group_enable=True),
         label=_('location'))
     guests = forms.CharField(widget=forms.HiddenInput())
+    captcha = ReCaptchaField(widget=ReCaptchaV3, required=True)
 
     class Meta:
         model = GroupReservation
@@ -335,6 +336,9 @@ class GroupReservationForm(forms.ModelForm):
             'data-target': '#modal_form',
             'data-doc-type': 'liability'
         })
+        
+        if not getattr(settings, 'ENABLE_RECAPTCHA', False):
+            self.fields.pop('captcha', None)
 
     def clean_guests(self):
         guests = self.cleaned_data.get('guests')

--- a/djangoplicity/visits/forms.py
+++ b/djangoplicity/visits/forms.py
@@ -62,7 +62,7 @@ class ReservationForm(forms.ModelForm):
     email_confirm = forms.EmailField(label=_('Confirm Email'))
     waiting_list_message = None
 
-    captcha = ReCaptchaField(widget=ReCaptchaV3, required=True)
+    captcha = ReCaptchaField(widget=ReCaptchaV3, required=True, label=False)
 
     if getattr(settings, 'VISITS_COVID_CONDITIONS', False):
         not_has_tested_positive_for_covid = forms.BooleanField(
@@ -305,7 +305,7 @@ class GroupReservationForm(forms.ModelForm):
         queryset=Activity.objects.filter(group_enable=True),
         label=_('location'))
     guests = forms.CharField(widget=forms.HiddenInput())
-    captcha = ReCaptchaField(widget=ReCaptchaV3, required=True)
+    captcha = ReCaptchaField(widget=ReCaptchaV3, required=True, label=False)
 
     class Meta:
         model = GroupReservation


### PR DESCRIPTION
- Add captcha v3 for Group Reservation Form for prevent attacks according with ticket (CEE-6632)
- Hide captcha forms for Reservation and GroupReservation

## Screenshot
<img width="3164" height="1104" alt="Screenshot 2026-05-07 at 4 54 43 PM" src="https://github.com/user-attachments/assets/efff11da-6180-496a-a0de-6d952c14d3e0" />
