### PR TITLE
Feature/Add support for embed visits & reservations

### DIFF
--- a/djangoplicity/visits/views.py
+++ b/djangoplicity/visits/views.py
@@ -154,8 +154,7 @@ class ReservationCreateView(CreateView):
 
     def get_success_url(self, **kwargs):
         self.object.send_confirmation_email()
-        # return reverse('visits-reservation-confirm', args=[self.object.code])
-        return translation_reverse(
+        url = translation_reverse(
             'visits-reservation-confirm',
             args=[self.object.code],
             lang=self.object.language.code)

--- a/djangoplicity/visits/views.py
+++ b/djangoplicity/visits/views.py
@@ -158,6 +158,9 @@ class ReservationCreateView(CreateView):
             'visits-reservation-confirm',
             args=[self.object.code],
             lang=self.object.language.code)
+        if self.request.GET.get('embed') == 'true':
+            url += '?embed=true'
+        return url
 
     def form_valid(self, form):
         reservation = form.save(commit=False)
@@ -215,11 +218,13 @@ class ReservationDeleteView(DeleteView):
 
     def get_success_url(self, **kwargs):
         self.object.send_deleted_email()
-        #  return reverse('visits-reservation-delete-confirm')
-        return translation_reverse(
+        url = translation_reverse(
             'visits-reservation-delete-confirm',
             args=[],
             lang=self.object.language.code)
+        if self.request.GET.get('embed') == 'true':
+            url += '?embed=true'
+        return url
 
 
 class ReservationConfirmView(DetailView):
@@ -252,11 +257,13 @@ class ReservationUpdateView(UpdateView):
 
     def get_success_url(self, **kwargs):
         self.object.send_updated_email()
-        #  return reverse('visits-reservation-confirm', args=[self.object.code])
-        return translation_reverse(
+        url = translation_reverse(
             'visits-reservation-confirm',
             args=[self.object.code],
             lang=self.object.language.code)
+        if self.request.GET.get('embed') == 'true':
+            url += '?embed=true'
+        return url
 
 
 class ReservationCancelView(ReservationUpdateView):

--- a/djangoplicity/visits/views.py
+++ b/djangoplicity/visits/views.py
@@ -45,6 +45,7 @@ from django.db.models import Sum
 from djangoplicity.visits.forms import ReservationForm, GroupReservationForm
 from djangoplicity.visits.models import Activity, Reservation, Showing, GroupReservation
 from djangoplicity.translation.models import translation_reverse
+from djangoplicity.utils.embed import embed_url
 from django.core.mail import send_mail, BadHeaderError
 
 
@@ -158,9 +159,7 @@ class ReservationCreateView(CreateView):
             'visits-reservation-confirm',
             args=[self.object.code],
             lang=self.object.language.code)
-        if self.request.GET.get('embed') == 'true':
-            url += '?embed=true'
-        return url
+        return embed_url(url, self.request.GET.get('embed') == 'true')
 
     def form_valid(self, form):
         reservation = form.save(commit=False)
@@ -222,9 +221,7 @@ class ReservationDeleteView(DeleteView):
             'visits-reservation-delete-confirm',
             args=[],
             lang=self.object.language.code)
-        if self.request.GET.get('embed') == 'true':
-            url += '?embed=true'
-        return url
+        return embed_url(url, self.request.GET.get('embed') == 'true')
 
 
 class ReservationConfirmView(DetailView):
@@ -261,9 +258,7 @@ class ReservationUpdateView(UpdateView):
             'visits-reservation-confirm',
             args=[self.object.code],
             lang=self.object.language.code)
-        if self.request.GET.get('embed') == 'true':
-            url += '?embed=true'
-        return url
+        return embed_url(url, self.request.GET.get('embed') == 'true')
 
 
 class ReservationCancelView(ReservationUpdateView):
@@ -389,6 +384,7 @@ class GroupReservationCreateUpdateView(UpdateView):
         return response
 
     def get_success_url(self):
-        return reverse('group-registration-update',
-                       args=[self.object.code])
+        url = reverse('group-registration-update',
+                      args=[self.object.code])
+        return embed_url(url, self.request.GET.get('embed') == 'true')
 


### PR DESCRIPTION
Modified the `get_success_url` method to persist the ?embed=true parameter through the reservation flow and keep embed templates working for external sites.

Files modified:
- djangoplicity-visits/djangoplicity/visits/views.py